### PR TITLE
FillParent and MatchParent awareness for content in scrollview

### DIFF
--- a/library/src/couk/jenxsol/parallaxscrollview/views/ParallaxScrollView.java
+++ b/library/src/couk/jenxsol/parallaxscrollview/views/ParallaxScrollView.java
@@ -3,7 +3,6 @@ package couk.jenxsol.parallaxscrollview.views;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -265,7 +264,6 @@ public class ParallaxScrollView extends ViewGroup
                 default:
                     childTop = parentTop + lp.topMargin;
             }
-            Log.d("Paralax","l: "+childLeft+" - w: "+width);
             mScrollView.layout(childLeft, childTop, childLeft + width, childTop + height);
 
         }

--- a/library/src/couk/jenxsol/parallaxscrollview/views/ParallaxScrollView.java
+++ b/library/src/couk/jenxsol/parallaxscrollview/views/ParallaxScrollView.java
@@ -178,10 +178,7 @@ public class ParallaxScrollView extends ViewGroup
 
         if (mScrollView != null)
         {
-            measureChild(mScrollView, MeasureSpec.makeMeasureSpec(
-                    MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.AT_MOST),
-                    MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec),
-                            MeasureSpec.AT_MOST));
+        	measureChildren(widthMeasureSpec, heightMeasureSpec);
 
             mScrollContentHeight = mScrollView.getChildAt(0).getMeasuredHeight();
             mScrollViewHeight = mScrollView.getMeasuredHeight();
@@ -218,9 +215,9 @@ public class ParallaxScrollView extends ViewGroup
         {
             final FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) mScrollView
                     .getLayoutParams();
-
-            final int width = mScrollView.getMeasuredWidth();
-            final int height = mScrollView.getMeasuredHeight();
+            
+            final int width = (lp.width==LayoutParams.MATCH_PARENT?this.getWidth():mScrollView.getMeasuredWidth());
+            final int height = (lp.height==LayoutParams.MATCH_PARENT?this.getHeight():mScrollView.getMeasuredHeight());
 
             int childLeft;
             int childTop;
@@ -265,14 +262,13 @@ public class ParallaxScrollView extends ViewGroup
                 default:
                     childTop = parentTop + lp.topMargin;
             }
-
             mScrollView.layout(childLeft, childTop, childLeft + width, childTop + height);
 
         }
 
         if (mBackground != null)
         {
-            final int scrollYCenterOffset = -mScrollView.getScrollY();
+            final int scrollYCenterOffset = mScrollView.getScrollY();
             final int offset = (int) (scrollYCenterOffset * mScrollDiff);
             // Log.d(TAG, "Layout Scroll Y: " + scrollYCenterOffset +
             // " ScrollDiff: " + mScrollDiff

--- a/library/src/couk/jenxsol/parallaxscrollview/views/ParallaxScrollView.java
+++ b/library/src/couk/jenxsol/parallaxscrollview/views/ParallaxScrollView.java
@@ -3,6 +3,7 @@ package couk.jenxsol.parallaxscrollview.views;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -216,8 +217,10 @@ public class ParallaxScrollView extends ViewGroup
             final FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) mScrollView
                     .getLayoutParams();
             
-            final int width = (lp.width==LayoutParams.MATCH_PARENT?this.getWidth():mScrollView.getMeasuredWidth());
-            final int height = (lp.height==LayoutParams.MATCH_PARENT?this.getHeight():mScrollView.getMeasuredHeight());
+            @SuppressWarnings("deprecation")
+			final int width = (lp.width==LayoutParams.MATCH_PARENT||lp.width==LayoutParams.FILL_PARENT)?this.getWidth():mScrollView.getMeasuredWidth();
+            @SuppressWarnings("deprecation")
+			final int height = (lp.height==LayoutParams.MATCH_PARENT||lp.height==LayoutParams.FILL_PARENT)?this.getHeight():mScrollView.getMeasuredHeight();
 
             int childLeft;
             int childTop;
@@ -262,6 +265,7 @@ public class ParallaxScrollView extends ViewGroup
                 default:
                     childTop = parentTop + lp.topMargin;
             }
+            Log.d("Paralax","l: "+childLeft+" - w: "+width);
             mScrollView.layout(childLeft, childTop, childLeft + width, childTop + height);
 
         }


### PR DESCRIPTION
Earlier if the first item width in the Scrollview was not fill_parent/match_parent the scrollview container was set to that size causing that the whole layout was exact that size.
